### PR TITLE
github: workflows: build: Add aarch64 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,45 +4,88 @@ on:
   push:
     branches:
     - "*"
+    - "*/*"
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+    - name: Install musl tools (For ring dependency `C`)
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          musl-tools \
+          llvm
+
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
-    - name: Install Rust and musl target
-      run: |
-        rustup update stable
-        rustup target add x86_64-unknown-linux-musl
+    - name: Set up Rust toolchain
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: stable
 
-    - name: Install musl tools
-      run: sudo apt-get update && sudo apt-get install -y musl-tools
+    # Set up cross-compilation to musl target
+    - name: Set up cross-compilation to musl
+      run: |
+        rustup target add x86_64-unknown-linux-musl
+        rustup target add aarch64-unknown-linux-musl
+        export PATH="$HOME/.cargo/bin:$PATH"
+
+    - name: Cache Cargo registry
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-registry-
+
+    - name: Cache Cargo target
+      uses: actions/cache@v3
+      with:
+        path: target
+        key: ${{ runner.os }}-cargo-target-${{ hashFiles('**/Cargo.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-target-
+
+    - name: Set environment variables for aarch64 (needed for ring as it uses `C` and gcc)
+      run: |
+        echo "CC_aarch64_unknown_linux_musl=clang" >> $GITHUB_ENV
+        echo "AR_aarch64_unknown_linux_musl=llvm-ar" >> $GITHUB_ENV
+        echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS='-Clink-self-contained=yes -Clinker=rust-lld'" >> $GITHUB_ENV
+        echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=rust-lld" >> $GITHUB_ENV
 
     - name: Build (Debug, musl, static)
       run: |
         cargo build --target x86_64-unknown-linux-musl
+        cargo build --target aarch64-unknown-linux-musl
+
+    - name: Archive Debug Binaries
+      uses: actions/upload-artifact@v4
+      with:
+        name: ducksync-debug
+        path: |
+          target/x86_64-unknown-linux-musl/debug/ducksync
+          target/aarch64-unknown-linux-musl/debug/ducksync
 
     - name: Run Tests (Debug)
-      run: |
-        cargo test --target x86_64-unknown-linux-musl
+      if: success()
+      run: cargo test --target x86_64-unknown-linux-musl
 
     - name: Build Release (musl, static)
       if: success()
       run: |
         cargo build --release --target x86_64-unknown-linux-musl
-
-    - name: Archive Debug Binary
-      uses: actions/upload-artifact@v4
-      with:
-        name: ducksync-debug
-        path: target/x86_64-unknown-linux-musl/debug/ducksync
+        cargo build --release --target aarch64-unknown-linux-musl
 
     - name: Archive Release Binary
       uses: actions/upload-artifact@v4
       with:
         name: ducksync-release
-        path: target/x86_64-unknown-linux-musl/release/ducksync
+        path: |
+          target/x86_64-unknown-linux-musl/release/ducksync
+          target/aarch64-unknown-linux-musl/release/ducksync


### PR DESCRIPTION
Add support for building the aarch64 target in the GitHub Actions workflow. This includes adding the target to rustup, building for both x86_64 and aarch64, and archiving the resulting binaries.

- Add rustup target for aarch64-unknown-linux-musl
- Build both x86_64 and aarch64 versions of the project
- Archive both x86_64 and aarch64 debug and release binaries