### PR TITLE
Add Unit Test for Ipify with Mock Fetcher

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,12 @@ lto = true
 strip = true
 opt-level = "z"
 
+[dev-dependencies]
+tokio = { version = "1.44", features = ["macros", "rt-multi-thread"] }
+wiremock = "0.5"
+
 [dependencies]
+async-trait = "0.1.88"
 clap = { version = "4.5" , features = ["derive"] } 
 directories = "6.0"
 env_logger = "0.11.8"

--- a/src/ipify.rs
+++ b/src/ipify.rs
@@ -50,3 +50,25 @@ impl<F: IpFetcher> Ipify<F> {
         ip_str.parse::<IpAddr>().map_err(|e| e.to_string())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::IpAddr;
+
+    struct MockFetcher;
+
+    #[async_trait::async_trait]
+    impl IpFetcher for MockFetcher {
+        async fn fetch_ip(&self, _url: &str) -> Result<String, String> {
+            Ok("127.0.0.1".to_string())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_ipv4_mock() {
+        let ipify = Ipify::new(MockFetcher {});
+        let result = ipify.ipv4().await;
+        assert_eq!(result.unwrap(), "127.0.0.1".parse::<IpAddr>().unwrap());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ type IpMap = Vec<(Vec<String>, String)>;
 
 async fn update_dns_cmd(domains: Vec<String>, token: String) -> Result<IpMap, String> {
     let duckdns = DuckDns::new();
-    let ipify = Ipify::new();
+    let ipify = Ipify::default();
 
     let res = match ipify.ipv6().await {
         Ok(ip) => Ok(ip),
@@ -82,7 +82,7 @@ async fn config_cmd(file: Option<String>) -> Result<IpMap, String> {
 
     let mut map = vec![];
     let duckdns = DuckDns::new();
-    let ipify = Ipify::new();
+    let ipify = Ipify::default();
 
     for domain in cfg.domains {
         if let Some(Ip::Public) = domain.ip {
@@ -91,7 +91,7 @@ async fn config_cmd(file: Option<String>) -> Result<IpMap, String> {
                 Err(e) => {
                     trace!("Could not resolve IPv6: {}", e);
                     ipify.ipv4().await
-                },
+                }
             };
 
             let Ok(ip) = res else {


### PR DESCRIPTION
Add a unit test for the `Ipify` library using a mock fetcher. Ensure the ipv4 function parses IP addresses correctly.

Changes:
- Implement mock `IpFetcher` trait.
- Add test for ipv4 using `tokio` and `async-trait`.
